### PR TITLE
Fixes OpenMP build error on vc14

### DIFF
--- a/src/lib/geogram/basic/process.cpp
+++ b/src/lib/geogram/basic/process.cpp
@@ -232,7 +232,7 @@ namespace {
             geo_argused(max_threads);
 
 #pragma omp parallel for schedule(dynamic)
-            for(index_t i = 0; i < threads.size(); i++) {
+            for(signed_index_t i = 0; i < threads.size(); i++) {
                 set_thread_id(threads[i],i);
                 set_current_thread(threads[i]);
                 threads[i]->run();


### PR DESCRIPTION
This ensures OpenMP 2.5 compatibility instead of 3+ and fixes:

Error C3016	'i': index variable in OpenMP 'for' statement must have signed integral type.

This fixes #6.