### PR TITLE
[cmake] install geogram_num_3rdparty

### DIFF
--- a/src/lib/third_party/numerics/CMakeLists.txt
+++ b/src/lib/third_party/numerics/CMakeLists.txt
@@ -29,3 +29,5 @@ set_target_properties(geogram_num_3rdparty PROPERTIES
                       SOVERSION ${VORPALINE_VERSION_MAJOR}
 		      FOLDER "GEOGRAM")
 
+install_devkit_targets(geogram_num_3rdparty)
+


### PR DESCRIPTION
This library is not installed by cmake for now.
